### PR TITLE
デプロイ後、修正あり

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,7 +1,7 @@
 class ProductsController < ApplicationController
   before_action :authenticate_user!, except:[:index, :show]
   before_action :set_product, only: [:show, :edit, :update, :destroy]
-  before_action :move_to_index, except:[:index, :show, :new, :create]
+  before_action :move_to_index, except:[:index, :show, :new, :create,]
 
   def index
     @products = Product.order("created_at DESC")
@@ -25,6 +25,9 @@ class ProductsController < ApplicationController
   end
 
   def edit
+      if @product.order != nil
+        redirect_to root_path
+      end
   end
 
   def update
@@ -55,7 +58,7 @@ class ProductsController < ApplicationController
   end
 
   def move_to_index
-      unless current_user.id  == @product.user.id
+      unless current_user.id  == @product.user.id 
         redirect_to  root_path
       end
   end

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -33,7 +33,7 @@
         <%= link_to '削除', product_path(@product.id), method: :delete, class:'item-destroy' %>
 
     <%# 商品が売れていない場合はこちらを表示しましょう %>
-      <% else %>
+      <% elsif @product.order == nil %>
        <%= link_to '購入画面に進む', product_orders_path(@product.id), method: :get ,class:"item-red-btn"%>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
       <% end %>


### PR DESCRIPTION
・soldoutの商品の詳細画面に「購入する」ボタンが残っていたので修正。
・出品者がsoldout後もurlから編集画面に遷移することができていたので修正。